### PR TITLE
fix(notification): prevent unsupported server notifications

### DIFF
--- a/app/code/community/FrontCommerce/Payline/Helper/Duplication.php
+++ b/app/code/community/FrontCommerce/Payline/Helper/Duplication.php
@@ -44,7 +44,6 @@ class FrontCommerce_Payline_Helper_Duplication
       $paylineSDK = Mage::helper('payline')->initPayline('CPT', $array['payment']['currency']);
       $paylineSDK->returnURL          = $fcBaseUrl . '/payline/process/widget';
       $paylineSDK->cancelURL          = $paylineSDK->returnURL;
-      $paylineSDK->notificationURL    = $paylineSDK->returnURL;
 
       // WALLET
       // ADD CONTRACT WALLET ARRAY TO $array


### PR DESCRIPTION
This PR prevents prevents notifications to reach the widget endpoint and trigger unsupported API calls to the Payline module.


Since the customer validates the payment synchronously, we don't need it in our current implementation.

Notifications lead to errors, and Payline will retry it several times which waste resources unnecessarily:
> NOTE : If your site cannot be accessed, Payline tries every minute during 2 hours. After this, notification is deactivated. You can find your payments in the Merchant Administration Centre web interface.
([source](https://docs.monext.fr/display/DT/Webservice+-+doWebPaymentRequest))
